### PR TITLE
Make Empty Response Behavior Configurable

### DIFF
--- a/surrealdb_rpc/tests/integration/test_websocket.py
+++ b/surrealdb_rpc/tests/integration/test_websocket.py
@@ -608,3 +608,7 @@ class TestWebsocketClient:
         assert all(
             int(r["id"].record_id.value) % 2 == int(r["odd"]) for r in response
         ), response
+        
+        response = connection.update("test_update:5", odd=False)
+        assert response == None
+        


### PR DESCRIPTION
#### **Summary**  
This PR introduces a configurable option for handling empty responses when updating non-existent records. Currently, the function at [line 276 in `surrealdb.py`](https://github.com/manu-schaaf/surrealdb-rpc.py/blob/18f262860276cf5b7112779b7b4246156a109807/surrealdb_rpc/client/websocket/surrealdb.py#L276) defaults to treating an empty response as non-erroneous (`False`). This behavior aligns with the database documentation but may not be suitable for all use cases.  

#### **Changes**  
- Added a new parameter: `empty_response_is_error` (default: `False`, preserving existing behavior).  
- This allows users to decide whether an empty response should be treated as an error.  
- Ensured backward compatibility—default behavior remains unchanged.  

#### **Use Case**  
Some workflows involve batch updates where certain IDs might not exist in the database. Instead of pre-checking for existence (which adds unnecessary WebSocket overhead), users can now choose to ignore or raise an error based on their needs.  

#### **Testing Progress**  
- [ ] Unit tests to validate configurable behavior  
- [ ] Integration tests for both `True` and `False` scenarios  

#### **Related Issue**  
Closes [[#1](https://github.com/manu-schaaf/surrealdb-rpc.py/issues/1)](https://github.com/manu-schaaf/surrealdb-rpc.py/issues/1)  
